### PR TITLE
Add support for PipeWire, PulseAudio, and Alsa

### DIFF
--- a/linux_voice_assistant/mpv_player.py
+++ b/linux_voice_assistant/mpv_player.py
@@ -1,6 +1,6 @@
 """
 Media player using mpv in a subprocess.
-
+Includes logic to detect the audio server being used (Pirewire, PulseAudio, Alsa).
 This refactored version simplifies the audio backend selection logic,
 improves readability with docstrings, and standardizes method signatures.
 """


### PR DESCRIPTION
Selects the best available audio output backend for mpv.
    
The selection follows a clear priority:
    1. A fully qualified device string (e.g., 'alsa/plughw:...') is used directly.
    2. A simple device name tries PipeWire, then PulseAudio, then ALSA.
    3. No device specified (or 'default') tries the default for PipeWire, PulseAudio, and ALSA in order.